### PR TITLE
Fixed github watcher count and removed icon from github button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,9 @@
+.media-content {
+	text-align: center;
+	margin: 0 auto;
+}
+
+.level-item {
+	text-align: center;
+	margin: 0 auto;
+}

--- a/index.html
+++ b/index.html
@@ -49,10 +49,32 @@
   <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
   <script>
     
+    var getJSON = function(url, callback) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', url, true);
+        xhr.responseType = 'json';
+        xhr.onload = function() {
+          var status = xhr.status;
+          if (status === 200) {
+            callback(null, xhr.response);
+          } else {
+            callback(status, xhr.response);
+          }
+        };
+        xhr.send();
+    };
+
     async function profile() {
       const github = await axios.get('https://api.github.com/users/serekkiri/repos')
         github.data.forEach(function(response) {
+          
+         const subscribers = axios.get(response.subscribers_url).then(function(res){
+          let subCount = res.data.length;
+         
+          
+
         const github = document.getElementById('github')
+        
         github.innerHTML += `
           <div class="box container">
             <article class="media hero">
@@ -82,15 +104,10 @@
                           <i class="fas fa-glasses" aria-hidden="true"></i>
                         </span>
                         &nbsp;
-                         ${response.watchers}
+                         ${subCount}
                       </a>
                     <a class="level-item" aria-label="like">
-                        <a class="button is-primary is-outlined" href="${response.html_url}"><span class="icon is-small">
-                            &nbsp;  
-                          <i class="fab fa-github" aria-hidden="true"></i>
-                            &nbsp;
-                            &nbsp;
-                        </span>Github</a></a>
+                        <a class="button is-primary is-outlined" href="${response.html_url}">Github</a>
                     </a>
                   </div>
                 </nav>
@@ -98,6 +115,8 @@
             </article>
           </div>
           ` 
+        
+        })
       })
       }
       window.onload = profile()

--- a/index.html
+++ b/index.html
@@ -48,21 +48,6 @@
   </footer>
   <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
   <script>
-    
-    var getJSON = function(url, callback) {
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', url, true);
-        xhr.responseType = 'json';
-        xhr.onload = function() {
-          var status = xhr.status;
-          if (status === 200) {
-            callback(null, xhr.response);
-          } else {
-            callback(status, xhr.response);
-          }
-        };
-        xhr.send();
-    };
 
     async function profile() {
       const github = await axios.get('https://api.github.com/users/serekkiri/repos')


### PR DESCRIPTION
Github doesn't have a watcher count stat anymore. Watchers are called subscribers now, and have their own API link. So for every repo found, it fetches subscribers array from the subscribers link in every repo, then displays the subscribers.count number for the watchers.